### PR TITLE
fix: command no longer moves user into the bash-tool directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ ssh username@i.p
  4. Copy and paste the script below into the server.
 
 ```sh
-git clone https://github.com/ExploreNYM/bash-tool ~/bash-tool && cd ~/bash-tool && ./scripts/explore-nym.sh && cd - &> /dev/null
+git clone https://github.com/ExploreNYM/bash-tool ~/bash-tool && ~/bash-tool/scripts/explore-nym.sh
 ```
 if you are using this tool after already installing manually select migrate.
 


### PR DESCRIPTION
### Associated Issue
#5 
### Description
The one line command on the README no longer makes the user cd into the bash-tool directory, it now runs the script from the directory where he pastes the line in, making so he stays in that directory after the script stops running.